### PR TITLE
Implement quote filtering by book

### DIFF
--- a/src/pages/api/quotes.js
+++ b/src/pages/api/quotes.js
@@ -6,8 +6,17 @@ export default async function handler(req, res) {
     const { db } = await connectToDatabase();
 
     if (req.method === 'GET') {
-      const quotes = await db.collection('quotes').find({}).toArray();
-      
+      const { type, book } = req.query;
+
+      if (type === 'books') {
+        const titles = await db.collection('quotes').distinct('bookTitle');
+        return res.status(200).json(titles.map((t) => ({ bookTitle: t })));
+      }
+
+      const filter = book ? { bookTitle: book } : {};
+
+      const quotes = await db.collection('quotes').find(filter).toArray();
+
       if (quotes.length === 0) {
         return res.status(404).json({ message: 'No quotes found' });
       }

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -254,6 +254,7 @@ export default function Home() {
                 position: 'absolute',
                 top: '10px',
                 left: '10px',
+                zIndex: 2,
               }}
             >
               <InputLabel id="book-select-label" sx={{ color: '#FBFEF9' }}>Select Book</InputLabel>
@@ -280,6 +281,7 @@ export default function Home() {
               ref={quoteCardRef}
               sx={{
                 position: 'relative',
+                zIndex: 1,
                 padding: { xs: '40px 20px', sm: '50px 30px', md: '60px 40px' },
                 borderRadius: '10px',
                 backgroundColor: '#000000',

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -202,79 +202,75 @@ export default function Home() {
          
 
           <Box sx={{ position: 'relative', width: '100%', maxWidth: { xs: '95%', sm: '80%', md: '600px' } }}>
-            <Box sx={{ position: 'absolute', top: '10px', right: '10px', zIndex: 1, display: 'flex' }}>
-              <IconButton
-                onClick={handleCopyQuote}
-                sx={{
-                  color: '#FBFEF9',
-                  padding: '4px',
-                  marginRight: '8px',
-                }}
+            <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', mb: 1 }}>
+              <FormControl
+                size="small"
+                sx={{ width: { xs: '150px', sm: '180px' } }}
               >
-                {isCopied ? (
-                  <CheckIcon fontSize="small" />
-                ) : (
-                  <ContentCopyIcon fontSize="small" />
-                )}
-                <Typography variant="caption" sx={{ ml: 0.5, fontSize: '0.6rem' }}>
-                  {isCopied ? 'Copied!' : 'Copy'}
-                </Typography>
-              </IconButton>
-              <IconButton
-                onClick={handleShare}
-                sx={{
-                  color: '#FBFEF9',
-                  padding: '4px',
-                }}
-              >
-                <ShareIcon fontSize="small" />
-                <Typography variant="caption" sx={{ ml: 0.5, fontSize: '0.6rem' }}>
-                  Share
-                </Typography>
-              </IconButton>
-              <IconButton
-                onClick={handleShareImage}
-                sx={{
-                  color: '#FBFEF9',
-                  padding: '4px',
-                  marginLeft: '8px',
-                }}
-              >
-                <ShareIcon fontSize="small" />
-                <Typography variant="caption" sx={{ ml: 0.5, fontSize: '0.6rem' }}>
-                  Share Image
-                </Typography>
-              </IconButton>
-            </Box>
+                <InputLabel id="book-select-label" sx={{ color: '#FBFEF9' }}>Select Book</InputLabel>
+                <Select
+                  labelId="book-select-label"
+                  value={selectedBook}
+                  label="Select Book"
+                  onChange={handleBookChange}
+                  sx={{
+                    color: '#FBFEF9',
+                    '.MuiOutlinedInput-notchedOutline': { borderColor: '#FBFEF9' },
+                    '& .MuiSvgIcon-root': { color: '#FBFEF9' },
+                  }}
+                >
+                  <MenuItem value="All Books">All Books</MenuItem>
+                  {bookInfo.bookTitles.map((title) => (
+                    <MenuItem key={title} value={title}>{title}</MenuItem>
+                  ))}
+                </Select>
+              </FormControl>
 
-            <FormControl
-              size="small"
-              sx={{
-                width: { xs: '150px', sm: '180px' },
-                position: 'absolute',
-                top: '10px',
-                left: '10px',
-                zIndex: 2,
-              }}
-            >
-              <InputLabel id="book-select-label" sx={{ color: '#FBFEF9' }}>Select Book</InputLabel>
-              <Select
-                labelId="book-select-label"
-                value={selectedBook}
-                label="Select Book"
-                onChange={handleBookChange}
-                sx={{
-                  color: '#FBFEF9',
-                  '.MuiOutlinedInput-notchedOutline': { borderColor: '#FBFEF9' },
-                  '& .MuiSvgIcon-root': { color: '#FBFEF9' },
-                }}
-              >
-                <MenuItem value="All Books">All Books</MenuItem>
-                {bookInfo.bookTitles.map((title) => (
-                  <MenuItem key={title} value={title}>{title}</MenuItem>
-                ))}
-              </Select>
-            </FormControl>
+              <Box sx={{ display: 'flex' }}>
+                <IconButton
+                  onClick={handleCopyQuote}
+                  sx={{
+                    color: '#FBFEF9',
+                    padding: '4px',
+                    marginRight: '8px',
+                  }}
+                >
+                  {isCopied ? (
+                    <CheckIcon fontSize="small" />
+                  ) : (
+                    <ContentCopyIcon fontSize="small" />
+                  )}
+                  <Typography variant="caption" sx={{ ml: 0.5, fontSize: '0.6rem' }}>
+                    {isCopied ? 'Copied!' : 'Copy'}
+                  </Typography>
+                </IconButton>
+                <IconButton
+                  onClick={handleShare}
+                  sx={{
+                    color: '#FBFEF9',
+                    padding: '4px',
+                  }}
+                >
+                  <ShareIcon fontSize="small" />
+                  <Typography variant="caption" sx={{ ml: 0.5, fontSize: '0.6rem' }}>
+                    Share
+                  </Typography>
+                </IconButton>
+                <IconButton
+                  onClick={handleShareImage}
+                  sx={{
+                    color: '#FBFEF9',
+                    padding: '4px',
+                    marginLeft: '8px',
+                  }}
+                >
+                  <ShareIcon fontSize="small" />
+                  <Typography variant="caption" sx={{ ml: 0.5, fontSize: '0.6rem' }}>
+                    Share Image
+                  </Typography>
+                </IconButton>
+              </Box>
+            </Box>
 
             <Paper
               elevation={0}

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -1,5 +1,5 @@
 import { useEffect, useState, useRef } from 'react';
-import { Container, Typography, Button, Paper, IconButton, Box, CircularProgress , TextField} from '@mui/material';
+import { Container, Typography, Button, Paper, IconButton, Box, CircularProgress, TextField, FormControl, InputLabel, Select, MenuItem } from '@mui/material';
 import ContentCopyIcon from '@mui/icons-material/ContentCopy';
 import CheckIcon from '@mui/icons-material/Check';
 import ShareIcon from '@mui/icons-material/Share';
@@ -17,19 +17,22 @@ export default function Home() {
   const [startId, setStartId] = useState("");
   const [endId, setEndId] = useState("");
   const [bookInfo, setBookInfo] = useState({ bookCount: 0, bookTitles: [] });
+  const [selectedBook, setSelectedBook] = useState('All Books');
 
 
 
   useEffect(() => {
-    
-    fetchQuotes();
     fetchBookInfo();
-
   }, []);
 
-  const fetchQuotes = async () => {
+  useEffect(() => {
+    fetchQuotes(selectedBook);
+  }, [selectedBook]);
+
+  const fetchQuotes = async (book) => {
     try {
-      const response = await fetch('/api/quotes');
+      const url = book && book !== 'All Books' ? `/api/quotes?book=${encodeURIComponent(book)}` : '/api/quotes';
+      const response = await fetch(url);
       const data = await response.json();
       setQuotes(data);
       if (data.length > 0) {
@@ -57,6 +60,10 @@ export default function Home() {
     }
   };
 
+  const handleBookChange = (event) => {
+    setSelectedBook(event.target.value);
+  };
+
   
 
     const handleUpload = async () => {
@@ -65,7 +72,7 @@ export default function Home() {
 
         if (response.status === 200) {
           setAlert({ severity: 'success', message: response.data.message });
-          fetchQuotes(); // Refresh the quotes
+          fetchQuotes(selectedBook); // Refresh the quotes
         }
       } catch (error) {
         console.error('Error uploading quotes:', error);
@@ -82,7 +89,7 @@ export default function Home() {
 
         if (response.status === 200) {
           setAlert({ severity: 'success', message: response.data.message });
-          fetchQuotes(); // Refresh the quotes
+          fetchQuotes(selectedBook); // Refresh the quotes
         }
       } catch (error) {
         console.error('Error deleting quotes:', error);
@@ -239,6 +246,26 @@ export default function Home() {
                 </Typography>
               </IconButton>
             </Box>
+
+            <FormControl fullWidth size="small" sx={{ mt: 2 }}>
+              <InputLabel id="book-select-label" sx={{ color: '#FBFEF9' }}>Select Book</InputLabel>
+              <Select
+                labelId="book-select-label"
+                value={selectedBook}
+                label="Select Book"
+                onChange={handleBookChange}
+                sx={{
+                  color: '#FBFEF9',
+                  '.MuiOutlinedInput-notchedOutline': { borderColor: '#FBFEF9' },
+                  '& .MuiSvgIcon-root': { color: '#FBFEF9' },
+                }}
+              >
+                <MenuItem value="All Books">All Books</MenuItem>
+                {bookInfo.bookTitles.map((title) => (
+                  <MenuItem key={title} value={title}>{title}</MenuItem>
+                ))}
+              </Select>
+            </FormControl>
 
             <Paper
               elevation={0}

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -247,7 +247,15 @@ export default function Home() {
               </IconButton>
             </Box>
 
-            <FormControl fullWidth size="small" sx={{ mt: 2 }}>
+            <FormControl
+              size="small"
+              sx={{
+                width: { xs: '150px', sm: '180px' },
+                position: 'absolute',
+                top: '10px',
+                left: '10px',
+              }}
+            >
               <InputLabel id="book-select-label" sx={{ color: '#FBFEF9' }}>Select Book</InputLabel>
               <Select
                 labelId="book-select-label"


### PR DESCRIPTION
## Summary
- add query parameters to `quotes` API for listing books and filtering by book
- show filter dropdown in the UI and reload quotes when selected

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6884334e8648833192ace660522c2ac7